### PR TITLE
Cfjello changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Of course, you can consider using the not recommended ones. For example why not 
 
 ## Special Characters
 
--  **$...** indicates a DOM node (e.g. $btn)
+-  **$...** indicates a DOM node (jQuery selector, e.g. $btn)
 
 ## 0-9
 
@@ -80,6 +80,7 @@ Of course, you can consider using the not recommended ones. For example why not 
 -  _**cert** certificate_
 -  **cfg** configuration
 -  **ch** channel
+-  **chk** check
 -  **char** character
 -  _**circ** circle_
 -  **clr** clear
@@ -100,7 +101,7 @@ Of course, you can consider using the not recommended ones. For example why not 
 -  **csum** checksum
 -  **ctrl** control
 -  **ctx** context
--  **cur** current
+-  **cur / curr** current
 -  ~~**cpy** copy~~
 
 ## D
@@ -112,31 +113,34 @@ Of course, you can consider using the not recommended ones. For example why not 
 -  **def** default / define
 -  **del** delete
 -  **dest** destination
--  **dev** developer / development / device
+-  **dev** development / device /  developer
 -  **diff** difference
--  **dir** direction / directory
+-  **dir** directory / direction
 -  **dis** disable
 -  **disp** display
 -  **doc** document
 -  **drv** driver
 -  **dsc** descriptor
 -  **dt** delta time
+-  **dyn** dynamic
 
 ## E
 
 -  **e** event
--  **e.g.** example (in comments)
+-  **e.g.** example (only used in comments)
 -  **en** enable
 -  **env** environment
 -  _**eq** equal_
 -  **err** error
 -  **exe** executable
 -  **expr** expression
+-  **ext** extension
 
 ## F
 
 -  _**f** function_
 -  _**f** file_
+-  **fac** factory
 -  **fig** figure
 -  **fmt** format
 -  **fp** function pointer
@@ -166,27 +170,30 @@ Of course, you can consider using the not recommended ones. For example why not 
 -  **inc** include / increase
 -  **info** information
 -  **init** initialize (e.g. for methods which initialize new objects)
+-  **ins** insert
+-  **intf** interface
 -  **int** integer
+-  **itor** iterator
 
 ## J
 
--  **j** integer iterator (only with **i**)
+-  **j** integer iterator (variable iterator, only used with **i** and **k**)
 
 ## K
 
--  **k** integer iterator (only with **i** and **j**)
--  **k** object key (only with **v**)
+-  **k** integer iterator (variable iterator, only used like **i** and **j**)
+-  **key** object key (variable iterator, only  used with **val**)
 
 ## L
 
 -  **lang** language
 -  _**lat** latitude_
 -  **lib** library
--  _**le** less or equal_
+-  _**le** less or equal (binary relational operator)_
 -  **len** length
 -  **ll** linked list
 -  _**lon** longitude_
--  **lt** less than
+-  _**lt** less than  (binary relational operator)_
 
 ## M
 
@@ -194,39 +201,45 @@ Of course, you can consider using the not recommended ones. For example why not 
 -  **max** maximum
 -  **mcu** microcontroller
 -  **mem** memory
+-  **meta** metadata
 -  **mid** middle
 -  **min** minimum
 -  **misc** miscellaneous
 -  **mng** manager
 -  **mod** modulo
 -  **msg** message
+-  **mut** mutable
 
 ## N
 
--  _**n** no (only with **yes**)_
+-  _**n** no (boolean value, only with **yes**)_
 -  **nav** navigation
--  _**ne** not equal_
+-  _**ne** not equal (binary relational operator)_
 -  **net** network
+-  **nl** newline
 -  **num** number
 
 ## O
 
 -  **obj** object
 -  ~~**ord** order~~
+-  **ok** success
 -  **op** operation
--  **opt** optional
+-  **opt** option / optional
 -  **os** operating system
 
 ## P
 
 -  _**p** pointer_
 -  **param** parameter
+-  **perf** performance
 -  **pic** picture
 -  **pos** position
 -  **pred** prediction
 -  **pref** preference
 -  **prev** previous
 -  **proc** process
+-  **prod** production
 -  **prof** profiler
 -  **ptr** pointer
 -  **pwr** power
@@ -240,19 +253,22 @@ Of course, you can consider using the not recommended ones. For example why not 
 
 -  _**r** radius_
 -  **rand** random
+-  **rec** record
 -  _**rect** rectangle_
 -  **recv** receive
+-  **ref** reference
 -  **rem** remove
 -  **repo** repository
 -  **req** required / requested
 -  **res** response / result
 -  **ret** return
 -  **rev** revision
+-  **rgx / regex** regular expression
 -  **rng** range
 
 ## S
 
--  \_**s** signed as prefix (s8 variable type)
+-  _**s** signed as prefix (variable type modifier, e.g. s8)_
 -  _**sem** semaphore_
 -  **sel** selected / selection
 -  **sin** sine
@@ -266,37 +282,43 @@ Of course, you can consider using the not recommended ones. For example why not 
 
 ## T
 
--  _**t** time / type (e.g. uint8_t)_
+-  _**t** time / type (variable type modifier, e.g. uint8_t)_
 -  _**temp** temperature_
 -  **temp / tmp** temporary
 -  ~~**tgl** toggle~~
+-  **tmpl** template
 -  **tmr** timer
 -  **ts** timestamp
 -  ~~**txt** text~~
+-  **tz** timezone
 
 ## U
 
--  _**u** unsigned as prefix (e.g. uint8_t)_
+-  _**u** unsigned as prefix (variable type modifier, e.g. uint8_t)_
+-  **upd** update
 -  ~~**usr** user~~
+-  **utl / util** utility
+
 
 ## V
 
--  **v** value (only with **k**)
--  _**v** vector / version_
+-  _**v** value (variable iterator, only with **k**)_
 -  **val** value
 -  **var** variable
+-  **vec** vector
 -  **ver** version / vertical
 
 ## W
 
 -  _**w** width_
 -  **win** window
+-  **ws** white space
 
 ## X
 
 ## Y
 
--  _**y** yes (only with **n**)_
+-  _**y** yes (boolean value, only with **n**)_
 
 ## Z
 

--- a/abbr.json
+++ b/abbr.json
@@ -1,0 +1,1459 @@
+{
+"abbreviations":[
+    {
+        "abbr": "$...", 
+        "desc": "indicates a DOM node", 
+        "domain": "jQuery selector", 
+        "constraint": "",
+        "example": "$btn"
+    },
+    {
+        "abbr": "2", 
+        "desc": "to", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": "copy2mem"
+    },
+    {
+        "abbr": "abbr", 
+        "desc": "abbreviation", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "abs", 
+        "desc": "absolute number", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "addr", 
+        "desc": "address", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "alloc", 
+        "desc": "allocate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "alt", 
+        "desc": "alternative", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "alt", 
+        "desc": "alternate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "app", 
+        "desc": "application", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "arg", 
+        "desc": "argument", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "arr", 
+        "desc": "array", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "async", 
+        "desc": "asynchronous", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "attr", 
+        "desc": "attribute", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "auth", 
+        "desc": "authenticate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "auth", 
+        "desc": "authentication", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "avg", 
+        "desc": "average", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "bat", 
+        "desc": "battery", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "bg", 
+        "desc": "background", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "bin", 
+        "desc": "binary", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "bool", 
+        "desc": "boolean", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "btn", 
+        "desc": "button", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "buf", 
+        "desc": "buffer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "calc", 
+        "desc": "calculate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cb", 
+        "desc": "callback", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cert", 
+        "desc": "certificate", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cfg", 
+        "desc": "configuration", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ch", 
+        "desc": "channel", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "chk", 
+        "desc": "check", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "char", 
+        "desc": "character", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "circ", 
+        "desc": "circle", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "clr", 
+        "desc": "clear", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cmd", 
+        "desc": "command", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cmp", 
+        "desc": "compare", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cnt", 
+        "desc": "counter", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "concat", 
+        "desc": "concatenate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "conf", 
+        "desc": "configuration", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "config", 
+        "desc": "configuration", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "conn", 
+        "desc": "connection", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cont", 
+        "desc": "continue", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "conv", 
+        "desc": "conversation", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "col", 
+        "desc": "column", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "coll", 
+        "desc": "collection", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "coord", 
+        "desc": "coordinate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cos", 
+        "desc": "cosines", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "csum", 
+        "desc": "checksum", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ctrl", 
+        "desc": "control", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ctx", 
+        "desc": "context", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "cur", 
+        "desc": "current", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "curr", 
+        "desc": "current", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "db", 
+        "desc": "database", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dbg", 
+        "desc": "debug", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dec", 
+        "desc": "decimal", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dec", 
+        "desc": "decrease", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "def", 
+        "desc": "default", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "def", 
+        "desc": "define", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "del", 
+        "desc": "delete", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dest", 
+        "desc": "destination", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dev", 
+        "desc": "development", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dev", 
+        "desc": "device", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dev", 
+        "desc": "developer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "diff", 
+        "desc": "difference", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dir", 
+        "desc": "directory", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dir", 
+        "desc": "direction", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dis", 
+        "desc": "disable", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "disp", 
+        "desc": "display", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "doc", 
+        "desc": "document", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "drv", 
+        "desc": "driver", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dsc", 
+        "desc": "descriptor", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dt", 
+        "desc": "delta time", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "dyn", 
+        "desc": "dynamic", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "e", 
+        "desc": "event", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "e.g.", 
+        "desc": "example", 
+        "domain": "generic", 
+        "constraint": "only used in comments",
+        "example": ""
+    },
+    {
+        "abbr": "en", 
+        "desc": "enable", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "env", 
+        "desc": "environment", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "eq", 
+        "desc": "equal", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "err", 
+        "desc": "error", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "exe", 
+        "desc": "executable", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "expr", 
+        "desc": "expression", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ext", 
+        "desc": "extension", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "f", 
+        "desc": "function", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "f", 
+        "desc": "file", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "fac", 
+        "desc": "factory", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "fig", 
+        "desc": "figure", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "fmt", 
+        "desc": "format", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "fp", 
+        "desc": "function pointer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "func", 
+        "desc": "function", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ge", 
+        "desc": "greater or equal", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "gen", 
+        "desc": "generate", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "gt", 
+        "desc": "greater then", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "h", 
+        "desc": "height", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "hex", 
+        "desc": "hexadecimal", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "hor", 
+        "desc": "horizontal", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "hw", 
+        "desc": "hardware", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "i", 
+        "desc": "integer iterator", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "id", 
+        "desc": "identifier", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "idx", 
+        "desc": "index", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "iface", 
+        "desc": "interface", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "img", 
+        "desc": "image", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "inc", 
+        "desc": "include", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "inc", 
+        "desc": "increase", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "info", 
+        "desc": "information", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "init", 
+        "desc": "initialize", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": "for methods which initialize new objects"
+    },
+    {
+        "abbr": "ins", 
+        "desc": "insert", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "intf", 
+        "desc": "interface", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "int", 
+        "desc": "integer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "itor", 
+        "desc": "iterator", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "j", 
+        "desc": "integer iterator", 
+        "domain": "variable iterator", 
+        "constraint": "only used with **i** and **k**",
+        "example": ""
+    },
+    {
+        "abbr": "k", 
+        "desc": "integer iterator", 
+        "domain": "variable iterator", 
+        "constraint": "only used like **i** and **j**",
+        "example": ""
+    },
+    {
+        "abbr": "key", 
+        "desc": "object key", 
+        "domain": "variable iterator", 
+        "constraint": "only  used with **val**",
+        "example": ""
+    },
+    {
+        "abbr": "lang", 
+        "desc": "language", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "lat", 
+        "desc": "latitude", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "lib", 
+        "desc": "library", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "le", 
+        "desc": "less or equal", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "len", 
+        "desc": "length", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ll", 
+        "desc": "linked list", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "lon", 
+        "desc": "longitude", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "lt", 
+        "desc": "less than", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "max", 
+        "desc": "maximum", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mcu", 
+        "desc": "microcontroller", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mem", 
+        "desc": "memory", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "meta", 
+        "desc": "metadata", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mid", 
+        "desc": "middle", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "min", 
+        "desc": "minimum", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "misc", 
+        "desc": "miscellaneous", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mng", 
+        "desc": "manager", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mod", 
+        "desc": "modulo", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "msg", 
+        "desc": "message", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "mut", 
+        "desc": "mutable", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "n", 
+        "desc": "no", 
+        "domain": "boolean value", 
+        "constraint": "only with **yes**",
+        "example": ""
+    },
+    {
+        "abbr": "nav", 
+        "desc": "navigation", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ne", 
+        "desc": "not equal", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "net", 
+        "desc": "network", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "nl", 
+        "desc": "newline", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "num", 
+        "desc": "number", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "obj", 
+        "desc": "object", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ok", 
+        "desc": "success", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "op", 
+        "desc": "operation", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "opt", 
+        "desc": "option", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "opt", 
+        "desc": "optional", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "os", 
+        "desc": "operating system", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "p", 
+        "desc": "pointer", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "param", 
+        "desc": "parameter", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "perf", 
+        "desc": "performance", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "pic", 
+        "desc": "picture", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "pos", 
+        "desc": "position", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "pred", 
+        "desc": "prediction", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "pref", 
+        "desc": "preference", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "prev", 
+        "desc": "previous", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "proc", 
+        "desc": "process", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "prod", 
+        "desc": "production", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "prof", 
+        "desc": "profiler", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ptr", 
+        "desc": "pointer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "pwr", 
+        "desc": "power", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "px", 
+        "desc": "pixel", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "q", 
+        "desc": "query", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "qry", 
+        "desc": "query", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "r", 
+        "desc": "radius", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rand", 
+        "desc": "random", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rec", 
+        "desc": "record", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rect", 
+        "desc": "rectangle", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "recv", 
+        "desc": "receive", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ref", 
+        "desc": "reference", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rem", 
+        "desc": "remove", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "repo", 
+        "desc": "repository", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "req", 
+        "desc": "required", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "req", 
+        "desc": "requested", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "res", 
+        "desc": "response", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "res", 
+        "desc": "result", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ret", 
+        "desc": "return", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rev", 
+        "desc": "revision", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rgx", 
+        "desc": "regular expression", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "regex", 
+        "desc": "regular expression", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "rng", 
+        "desc": "range", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "s", 
+        "desc": "signed as prefix", 
+        "domain": "variable type modifier", 
+        "constraint": "",
+        "example": "s8"
+    },
+    {
+        "abbr": "sem", 
+        "desc": "semaphore", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "sel", 
+        "desc": "selected", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "sel", 
+        "desc": "selection", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "sin", 
+        "desc": "sine", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "seq", 
+        "desc": "sequence", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "sqrt", 
+        "desc": "square root", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "src", 
+        "desc": "source", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "stat", 
+        "desc": "statistics", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "std", 
+        "desc": "standard", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "str", 
+        "desc": "string", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "sync", 
+        "desc": "synchronize", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "t", 
+        "desc": "time", 
+        "domain": "variable type modifier", 
+        "constraint": "",
+        "example": "uint8_t"
+    },
+    {
+        "abbr": "t", 
+        "desc": "type", 
+        "domain": "variable type modifier", 
+        "constraint": "",
+        "example": "uint8_t"
+    },
+    {
+        "abbr": "temp", 
+        "desc": "temperature", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "temp", 
+        "desc": "temporary", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "tmp", 
+        "desc": "temporary", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "tmpl", 
+        "desc": "template", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "tmr", 
+        "desc": "timer", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ts", 
+        "desc": "timestamp", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "tz", 
+        "desc": "timezone", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "u", 
+        "desc": "unsigned as prefix", 
+        "domain": "variable type modifier", 
+        "constraint": "",
+        "example": "uint8_t"
+    },
+    {
+        "abbr": "upd", 
+        "desc": "update", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "utl", 
+        "desc": "utility", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "util", 
+        "desc": "utility", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "v", 
+        "desc": "value", 
+        "domain": "variable iterator", 
+        "constraint": "only with **k**",
+        "example": ""
+    },
+    {
+        "abbr": "val", 
+        "desc": "value", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "var", 
+        "desc": "variable", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "vec", 
+        "desc": "vector", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ver", 
+        "desc": "version", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ver", 
+        "desc": "vertical", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "w", 
+        "desc": "width", 
+        "domain": "specific", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "win", 
+        "desc": "window", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "ws", 
+        "desc": "white space", 
+        "domain": "generic", 
+        "constraint": "",
+        "example": ""
+    },
+    {
+        "abbr": "y", 
+        "desc": "yes", 
+        "domain": "boolean value", 
+        "constraint": "only with **n**",
+        "example": ""
+    }
+]}

--- a/genJson.pl
+++ b/genJson.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 # 
 # Perl script to generate a json abbriviation file from README.md 
+#  Usage in a Bash shell: ./genJson.pl > abbr.json
 #
 use warnings;
 use strict;

--- a/genJson.pl
+++ b/genJson.pl
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+# 
+# Perl script to generate a json abbriviation file from README.md 
+#
+use warnings;
+use strict;
+
+my $filename = '.\README.md';
+my $counter  = 0;
+my @jsonArr  = ();
+sub  trim { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };
+
+open(FH, '<', $filename) or die $!;
+
+print "{\n" . '"abbreviations":' . "[\n";
+
+while(<FH>){
+    ++$counter;
+    next if ( $_ =~ m/(~~)/);
+    if ( $counter > 40 ) {
+        if ( $_ =~ /-[ \t]/ ) {
+            my ( $abbr, $desc) = ($_ =~ m/\*\*([^*]*)\*\*[ \t]*([^\(_~]+)/);
+            my $domain= "generic";
+            if ( $_ =~ m/^-[ \t]*(_)[ \t]*\*\*/) { $domain = "specific"; }
+
+            my $comment    = "";
+            my $example    = "";
+            my $constraint = "";
+            if ($_ =~ m/\(([^\)]+)\)/) { $comment = $1; }
+            if (length($comment) > 0) {
+                if ( $comment =~ m/^([^,]+),(.*)$/ ) {
+                    $domain = trim($1);
+                    $comment = trim($2)
+                }
+                if ( $comment =~  m/^e\.g\.(.*)/ ) { 
+                    $example = trim($1); 
+                }
+                elsif ( $comment =~  m/^(only[ \t].*)/ ) {
+                    $constraint = trim($1);
+                }
+            }
+
+
+            my @abbrArr = split('/', $abbr);
+            my @descArr = split('/', $desc);
+            foreach my $ab (@abbrArr) {
+                foreach my $ds (@descArr) {
+                    push(@jsonArr, "    {\n        " 
+                        . '"abbr": "'    . trim($ab) . '", ' 
+                        . "\n        " 
+                        . '"desc": "'    . trim($ds) . '", ' 
+                        . "\n        " 
+                        . '"domain": "'   . $domain . '", '
+                        . "\n        " 
+                        . '"constraint": "' . $constraint . '",'
+                        . "\n        " 
+                        . '"example": "' . $example . '"'
+                        . "\n    },");
+                }
+            }
+        }
+    }
+}
+my $lastEntry = pop(@jsonArr);
+chop($lastEntry);
+push(@jsonArr, $lastEntry);
+print join("\n", @jsonArr),  "\n]}\n";
+close(FH);


### PR DESCRIPTION
Changes I have made:

- I have added a Perl script that can generate a abbr.json file (excluding the striked entries)
- I have updated the README.mb file with my new abbreviation suggestions
- I have updated the the optional descriptions within '(' ... ')' to make them machine redable, using the fomat : **( domain type, 'e.g.'  example | 'only' constraint )**. Have a look to see whether you like it.