### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,16 @@
 
 # Contributing
 
-1. Please, create an issue or PR and add new abbreviations or edit the existing ones.
-2. Don't list acronyms (e.g. RAM, CPU, SQL) or conventions (i, j, k for iterators).
+1. Please create an issue or PR and add new abbreviations or edit the existing ones.
+2. Don't list acronyms (e.g., *RAM, CPU, SQL*) or conventions (*i, j, k* for iterators).
 3. Keep alphabetical order.
 5. Don't use capitals.
 6. Use singular and neutral form.
 
 ## Format
-- 🟢 **abbr/s** • **value/s** (e.g. **example/s**)
-- 🟡 **abbr/s** • **value/s** (e.g. **example/s**) {**context/s**}
-- 🔴 **abbr/s** • **value/s** (e.g. **example/s**) {**context/s**}
 
+- 🟢 **abbrs** • **long forms** (e.g., **examples**)
+- 🟡 **abbrs** • **long forms** (e.g., **examples**) {**contexts**}
+- 🔴 **abbrs** • **long forms** (e.g., **examples**) {**contexts**}
+
+Separate multiple abbreviations or long forms with <code>&nbsp;/&nbsp;</code>.


### PR DESCRIPTION
- In American English, "e.g." should be surrounded by commas. And programming already favors American spelling variants (e.g., "color" instead of "colour"). "The consensus seems to be in favor of the comma in American usage; against it in British usage." (https://www.dailywritingtips.com/comma-after-i-e-and-e-g/)
- Regarding using "/s" for plurals: https://english.stackexchange.com/a/576145/296389. I didn't change it to "(s)" or "[s]", because, in a generic placeholder context, plurals can also mean single elements.